### PR TITLE
refactor

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -45,7 +45,7 @@ impl CommandHandler {
     pub fn event_to_command(event: &Event, in_help_mode: bool) -> Command {
         if in_help_mode {
             if let Event::Key(key) = event {
-                if *key == Esc {
+                if *key == Esc || *key == Char('h') {
                     return Command::ExitHelp;
                 }
             }

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -67,28 +67,6 @@ impl Grid {
         }
     }
 
-    // =============================
-    // Positions relative a cell (C).
-    //
-    // E  - in front
-    // SE - diagonal front below
-    // S  - below
-    // SW - diagonal behind below
-    // W  - behind
-    // NW - diagonal behind above
-    // N - above
-    // NE - diagonal front above
-    //
-    // =============================
-    //
-    //        NW     N    NE
-    //           \   |   /
-    //         W -   C   - E
-    //           /   |   \
-    //        SW     S    SE
-    //
-    // =============================
-
     fn compute_health(health: &Health, living_neighbors: usize) -> Health {
         match (health, living_neighbors) {
             (Alive, 2) => Alive,

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ fn create_default_pattern() -> Vec<PatternType> {
         patterns: vec![Pattern {
             name: String::from("blinker"),
             matrix: vec![vec![Alive, Alive, Alive]],
+            rotation_count: 0,
         }],
     }]
 }

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -88,10 +88,24 @@ impl Orchestrator {
     }
 
     fn render_help(&self) {
+        let rotation_count = self
+            .last_pattern
+            .map(|idx| {
+                self.configuration[self.current_pattern_type].patterns[idx].rotation_count
+            })
+            .unwrap_or(0);
+        let render_state = RenderState {
+            cur_pos: &self.cur_pos,
+            running: self.running,
+            configuration: &self.configuration,
+            current_pattern_type: self.current_pattern_type,
+            last_pattern: self.last_pattern,
+            rotation_count,
+        };
         Renderer::render_help(
             &self.viewport_size,
-            self.grid.get_size().height,
-            &self.configuration,
+            self.grid.get_size(),
+            &render_state,
         );
     }
 

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use std::time::Instant;
 
 use termion::event::Event;
-use termion::event::Key::Esc;
+use termion::event::Key::{Char, Esc};
 
 use crate::commands::{Command, CommandHandler};
 use crate::coordinates::Coordinates;
@@ -263,19 +263,19 @@ impl Orchestrator {
 
             let result = rx.recv_timeout(Duration::from_millis(25));
             if let Ok(event) = result {
-                // Handle help mode state
+                    // Handle help mode state
                 if let Event::Key(key) = &event {
                     if !wait_for_state.is_empty() {
                         if wait_for_state.contains(key) {
                             wait_for_state.clear();
-                            if key == &Esc {
+                            if key == &Esc || key == &Char('h') {
                                 in_help_mode = false;
                                 self.render();
                             }
                         }
                         continue;
                     }
-                    if key == &Esc && in_help_mode {
+                    if (key == &Esc || key == &Char('h')) && in_help_mode {
                         in_help_mode = false;
                         self.render();
                         continue;
@@ -288,6 +288,7 @@ impl Orchestrator {
                     Command::ShowHelp => {
                         in_help_mode = true;
                         wait_for_state.push(Esc);
+                        wait_for_state.push(Char('h'));
                     }
                     Command::ExitHelp => {
                         in_help_mode = false;

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -7,9 +7,11 @@ use crate::health::Health;
 pub struct Pattern {
     pub name: String,
     pub matrix: Vec<Vec<Health>>,
+    #[serde(default)]
+    pub rotation_count: usize, // 0-3 = 0°, 90°, 180°, 270°
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct PatternType {
     pub name: String,
     pub patterns: Vec<Pattern>,
@@ -47,6 +49,7 @@ impl Pattern {
         Pattern {
             name: self.name.clone(),
             matrix: rotated,
+            rotation_count: self.rotation_count,
         }
     }
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -42,7 +42,7 @@ pub struct RenderState<'a> {
     pub configuration: &'a [pattern::PatternType],
     pub current_pattern_type: usize,
     pub last_pattern: Option<usize>,
-    pub last_pattern_rotation: &'a std::collections::HashMap<usize, usize>,
+    pub rotation_count: usize,
 }
 
 pub struct Renderer;
@@ -95,19 +95,16 @@ impl Renderer {
         viewport_size: &Size,
         render_state: &RenderState,
     ) {
-        let (last_pattern, last_rotation) = if let Some(last) = render_state.last_pattern {
+        let (last_pattern, rotation_angle) = if let Some(last) = render_state.last_pattern {
             let pattern = render_state.configuration[render_state.current_pattern_type].patterns[last]
                 .name
                 .as_str();
 
-            let rotation = render_state
-                .last_pattern_rotation
-                .get(&last)
-                .unwrap_or(&0);
+            let rotation = render_state.rotation_count * 90;
 
             (pattern, rotation)
         } else {
-            ("none", &0)
+            ("none", 0)
         };
 
         let width = viewport_size.width;
@@ -123,7 +120,7 @@ impl Renderer {
             },
             render_state.configuration[render_state.current_pattern_type].name,
             last_pattern,
-            last_rotation
+            rotation_angle
         );
 
         print!(

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -136,8 +136,8 @@ impl Renderer {
 
     pub fn render_help(
         viewport_size: &Size,
-        grid_height: usize,
-        configuration: &[pattern::PatternType],
+        grid_size: &Size,
+        render_state: &RenderState,
     ) {
         Self::render_header(viewport_size.width);
 
@@ -155,7 +155,7 @@ impl Renderer {
             current_line += 1;
         }
 
-        for pattern_type in configuration {
+        for pattern_type in render_state.configuration {
             let values: Vec<String> = pattern_type
                 .patterns
                 .iter()
@@ -186,9 +186,14 @@ impl Renderer {
             current_line += 1;
         }
 
-        for line in current_line..grid_height as u16 {
+        // Clear remaining lines up to viewport height (footer is at viewport_height + 1)
+        for line in current_line..(viewport_size.height + 1) as u16 {
             print!("{}{}", cursor::Goto(1, line), clear::CurrentLine);
         }
+        stdout().flush().unwrap();
+
+        // Render footer at the end
+        Self::render_footer(grid_size, viewport_size, render_state);
     }
 
     pub fn render_all(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces per-pattern rotation tracking and improves help toggling, with corresponding updates across input handling, state, and rendering.
> 
> - Input/help: `h` now also exits help (`commands.rs`, `orchestrator.rs`); wait-state handling updated to accept both `Esc` and `h`.
> - Pattern model: add `rotation_count` (0–3) with serde default; `Pattern`/`PatternType` now `Clone`; rotation now increments `rotation_count` and rotates the matrix; removed `last_pattern_rotation` map in favor of per-pattern state.
> - Rendering: `RenderState` carries `rotation_count`; footer shows rotation in degrees; `render_help` now takes `grid_size` and a `RenderState`, clears remaining lines, and renders the footer.
> - Defaults/placement: default `blinker` initialized with `rotation_count: 0`; placing last pattern uses the rotated matrix from configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d3b6523c280186309b92c0a40ef40d3e8ff8430. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->